### PR TITLE
Define all services as public

### DIFF
--- a/src/CoreShop/Payum/HeidelpayBundle/Resources/config/services.yml
+++ b/src/CoreShop/Payum/HeidelpayBundle/Resources/config/services.yml
@@ -1,4 +1,7 @@
 services:
+    _defaults:
+        public: true
+        
     CoreShop\Payum\HeidelpayBundle\Form\Payment\HeidelpayType:
         tags:
             - { name: coreshop.gateway_configuration_type, type: heidelpay }


### PR DESCRIPTION
Fixes the following bug: 

```
Argument 1 passed to Payum\Core\Gateway::addExtension() must implement interface Payum\Core\Extension\ExtensionInterface, string given, called in /var/www/vhosts/rescue3team.at/staging.rescue3team.at/releases/78/vendor/payum/core/Payum/Core/CoreGatewayFactory.php on line 249
```