### PR TITLE
Make handling of amount safer (do not use floats)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# composer
+/vendor/
+
+# PhpStorm / IDEA
+.idea

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,13 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "coreshop/payum-heidelpay": "1.0.*",
-        "coreshop/payum-bundle": "2.0.*"
+        "php": ">=7.1",
+        "coreshop/payum-heidelpay": "^1.0",
+        "coreshop/payum-bundle": "^2.0",
+        "ikr/money-math": "^1.0"
+    },
+    "require-dev": {
+        "roave/security-advisories": "dev-master"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=7.1",
         "coreshop/payum-heidelpay": "^1.0",
         "coreshop/payum-bundle": "^2.0",
-        "ikr/money-math": "^1.0"
+        "moneyphp/money": "^3.2"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"

--- a/src/CoreShop/Payum/HeidelpayBundle/Extension/PopulateHeidelpayExtension.php
+++ b/src/CoreShop/Payum/HeidelpayBundle/Extension/PopulateHeidelpayExtension.php
@@ -17,6 +17,7 @@ use CoreShop\Component\Core\Model\CustomerInterface;
 use CoreShop\Component\Order\Model\OrderInterface;
 use CoreShop\Component\Order\Repository\OrderRepositoryInterface;
 use CoreShop\Component\Core\Model\PaymentInterface;
+use MoneyMath\Decimal2;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Extension\Context;
 use Payum\Core\Extension\ExtensionInterface;
@@ -24,9 +25,7 @@ use Payum\Core\Request\Convert;
 
 final class PopulateHeidelpayExtension implements ExtensionInterface
 {
-    /**
-     * @var OrderRepositoryInterface
-     */
+    /** @var OrderRepositoryInterface */
     private $orderRepository;
 
     /**
@@ -40,7 +39,7 @@ final class PopulateHeidelpayExtension implements ExtensionInterface
     /**
      * @param Context $context
      */
-    public function onPostExecute(Context $context)
+    public function onPostExecute(Context $context): void
     {
         $action = $context->getAction();
 
@@ -99,24 +98,30 @@ final class PopulateHeidelpayExtension implements ExtensionInterface
 
         $result['language'] = $gatewayLanguage;
         $result['customer'] = $customerData;
-        $result['basket']['amount'] = round($result['basket']['amount'] / 100, 2);
+        $result['basket']['amount'] = $this->calcAmount($result['basket']['amount']);
 
-        $request->setResult((array)$result);
-
+        $request->setResult($result);
     }
 
     /**
-     * {@inheritdoc}
+     * @param int $amount
+     * @return string
      */
-    public function onPreExecute(Context $context)
+    private function calcAmount(int $amount): string
     {
+        $dividend = new Decimal2((string) $amount);
+        $divisor = new Decimal2('100.00');
 
+        return (string) Decimal2::div($dividend, $divisor);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function onExecute(Context $context)
+    /** {@inheritdoc} */
+    public function onPreExecute(Context $context): void
+    {
+    }
+
+    /** {@inheritdoc} */
+    public function onExecute(Context $context): void
     {
     }
 }

--- a/src/CoreShop/Payum/HeidelpayBundle/Extension/PopulateHeidelpayExtension.php
+++ b/src/CoreShop/Payum/HeidelpayBundle/Extension/PopulateHeidelpayExtension.php
@@ -17,7 +17,10 @@ use CoreShop\Component\Core\Model\CustomerInterface;
 use CoreShop\Component\Order\Model\OrderInterface;
 use CoreShop\Component\Order\Repository\OrderRepositoryInterface;
 use CoreShop\Component\Core\Model\PaymentInterface;
-use MoneyMath\Decimal2;
+use Money\Currencies\ISOCurrencies;
+use Money\Currency;
+use Money\Formatter\DecimalMoneyFormatter;
+use Money\Money;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Extension\Context;
 use Payum\Core\Extension\ExtensionInterface;
@@ -105,14 +108,16 @@ final class PopulateHeidelpayExtension implements ExtensionInterface
 
     /**
      * @param int $amount
+     * @param string $currency
      * @return string
      */
-    private function calcAmount(int $amount): string
+    private function calcAmount(int $amount, string $currency = 'EUR'): string
     {
-        $dividend = new Decimal2((string) $amount);
-        $divisor = new Decimal2('100.00');
+        $money = new Money($amount, new Currency($currency));
+        $currencies = new ISOCurrencies();
+        $moneyFormatter = new DecimalMoneyFormatter($currencies);
 
-        return (string) Decimal2::div($dividend, $divisor);
+        return $moneyFormatter->format($money);
     }
 
     /** {@inheritdoc} */

--- a/src/CoreShop/Payum/HeidelpayBundle/HeidelpayBundleException.php
+++ b/src/CoreShop/Payum/HeidelpayBundle/HeidelpayBundleException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CoreShop\Payum\HeidelpayBundle;
+
+class HeidelpayBundleException extends \Exception
+{
+}


### PR DESCRIPTION
With money math the behaviour of different "float-styles" is safely omitted. Works with Heidelpay - no need to send a "float".